### PR TITLE
Removed the link to the trac wiki

### DIFF
--- a/index.html
+++ b/index.html
@@ -120,7 +120,7 @@ Don't worry, there are <a href="http://wiki.openwrt.org/doc/howto/installopenwrt
 Furthermore, OpenWrt is built for dozens of different kinds of processors and architectures. 
 This cross-platform capability means that you can migrate to different hardware if you need additional performance. 
 And if you need to develop a specialized set of features for a project, OpenWrt's build environment allows you to create custom builds for any of the supported architectures and combinations of packages. 
-See the <a href="https://dev.openwrt.org/">Development Wiki</a> for details.
+See the <a href="http://wiki.openwrt.org/doc">wiki</a> for details.
 </p>
 
 <h4>How can I learn more about OpenWrt?</h4>


### PR DESCRIPTION
The trac wiki is basically empty. It'd be simpler for everyone if we consolidated on one wiki.
